### PR TITLE
Update scripts for ZSH and Ubuntu 20.04 compatibility

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -1,18 +1,28 @@
-#!/bin/bash
+#!/bin/sh
 
-if [ "$UID" != 0 ]; then
+if [ "$LOGNAME" != "root" ]; then
     echo "You need to run $0 through sudo"
+    exit 1
+fi
+
+if [ -x /usr/sbin/daemonize ]; then
+    DAEMONIZE=/usr/sbin/daemonize
+elif [ -x /usr/bin/daemonize ]; then
+    DAEMONIZE=/usr/bin/daemonize
+else
+    echo "Cannot execute daemonize to start systemd."
     exit 1
 fi
 
 SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
 if [ -z "$SYSTEMD_PID" ]; then
-    /usr/sbin/daemonize /usr/bin/unshare --fork --pid --mount-proc /lib/systemd/systemd --system-unit=basic.target
+    "$DAEMONIZE" /usr/bin/unshare --fork --pid --mount-proc /lib/systemd/systemd --system-unit=basic.target
     while [ -z "$SYSTEMD_PID" ]; do
         SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
     done
 fi
 
+USER_HOME="$(getent passwd | awk '{ FS=":" } /'"$SUDO_USER"'/ {print $6}')"
 if [ -n "$SYSTEMD_PID" ] && [ "$SYSTEMD_PID" != "1" ]; then
     if [ -n "$1" ] && [ "$1" != "bash --login" ] && [ "$1" != "/bin/bash --login" ]; then
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
@@ -21,7 +31,7 @@ if [ -n "$SYSTEMD_PID" ] && [ "$SYSTEMD_PID" != "1" ]; then
     else
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
             /bin/login -p -f "$SUDO_USER" \
-            $(/bin/cat "$HOME/.systemd-env" | grep -v "^PATH=")
+            $(/bin/cat "$USER_HOME/.systemd-env" | xargs printf '%q')
     fi
     echo "Existential crisis"
 fi

--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash --norc
 
 if [ "$LOGNAME" != "root" ]; then
     echo "You need to run $0 through sudo"

--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -1,38 +1,40 @@
-#!/bin/bash
+#!/bin/sh
 
-SYSTEMD_PID=$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')
-if [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" != "1" ]; then
+SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
+if [ "$LOGNAME" != "root" ] && ( [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" != "1" ] ); then
+    export | \
+        grep -E -v "^(declare -x )?BASH(=.*)?\$" | \
+        grep -E -v "^(declare -x )?BASH_ENV(=.*)?\$" | \
+        grep -E -v "^(declare -x )?DIRSTACK(=.*)?\$" | \
+        grep -E -v "^(declare -x )?EUID(=.*)?\$" | \
+        grep -E -v "^(declare -x )?GROUPS(=.*)?\$" | \
+        grep -E -v "^(declare -x )?HOME(=.*)?\$" | \
+        grep -E -v "^(declare -x )?HOSTNAME(=.*)?\$" | \
+        grep -E -v "^(declare -x )?HOSTTYPE(=.*)?\$" | \
+        grep -E -v "^(declare -x )?IFS='.*"$'\n'"'" | \
+        grep -E -v "^(declare -x )?LANG(=.*)?$=" | \
+        grep -E -v "^(declare -x )?LOGNAME(=.*)?\$" | \
+        grep -E -v "^(declare -x )?MACHTYPE(=.*)?\$" | \
+        grep -E -v "^(declare -x )?MAIL(=.*)?\$" | \
+        grep -E -v "^(declare -x )?NAME(=.*)?\$" | \
+        grep -E -v "^(declare -x )?OLDPWD(=.*)?\$" | \
+        grep -E -v "^(declare -x )?OPTERR(=.*)?\$" | \
+        grep -E -v "^(declare -x )?OPTIND(=.*)?\$" | \
+        grep -E -v "^(declare -x )?OSTYPE(=.*)?\$" | \
+        grep -E -v "^(declare -x )?PATH(=.*)?\$" | \
+        grep -E -v "^(declare -x )?PIPESTATUS(=.*)?\$" | \
+        grep -E -v "^(declare -x )?POSIXLY_CORRECT(=.*)?\$" | \
+        grep -E -v "^(declare -x )?PPID(=.*)?\$" | \
+        grep -E -v "^(declare -x )?PS1(=.*)?\$" | \
+        grep -E -v "^(declare -x )?PS4(=.*)?\$" | \
+        grep -E -v "^(declare -x )?SHELL(=.*)?\$" | \
+        grep -E -v "^(declare -x )?SHELLOPTS(=.*)?\$" | \
+        grep -E -v "^(declare -x )?SHLVL(=.*)?\$" | \
+        grep -E -v "^(declare -x )?SYSTEMD_PID(=.*)?\$" | \
+        grep -E -v "^(declare -x )?UID(=.*)?\$" | \
+        grep -E -v "^(declare -x )?USER(=.*)?\$" | \
+        grep -E -v "^(declare -x )?_(=.*)?\$" | sed -e 's|^declare -x ||g' > "$HOME/.systemd-env"
     export PRE_NAMESPACE_PATH="$PATH"
-    (set -o posix; set) | \
-        grep -v "^BASH" | \
-        grep -v "^DIRSTACK=" | \
-        grep -v "^EUID=" | \
-        grep -v "^GROUPS=" | \
-        grep -v "^HOME=" | \
-        grep -v "^HOSTNAME=" | \
-        grep -v "^HOSTTYPE=" | \
-        grep -v "^IFS='.*"$'\n'"'" | \
-        grep -v "^LANG=" | \
-        grep -v "^LOGNAME=" | \
-        grep -v "^MACHTYPE=" | \
-        grep -v "^NAME=" | \
-        grep -v "^OPTERR=" | \
-        grep -v "^OPTIND=" | \
-        grep -v "^OSTYPE=" | \
-        grep -v "^PIPESTATUS=" | \
-        grep -v "^POSIXLY_CORRECT=" | \
-        grep -v "^PPID=" | \
-        grep -v "^PS1=" | \
-        grep -v "^PS4=" | \
-        grep -v "^SHELL=" | \
-        grep -v "^SHELLOPTS=" | \
-        grep -v "^SHLVL=" | \
-        grep -v "^SYSTEMD_PID=" | \
-        grep -v "^UID=" | \
-        grep -v "^USER=" | \
-        grep -v "^_=" | \
-        cat - > "$HOME/.systemd-env"
-    echo "PATH='$PATH'" >> "$HOME/.systemd-env"
     exec sudo /usr/sbin/enter-systemd-namespace "$BASH_EXECUTION_STRING"
 fi
 if [ -n "$PRE_NAMESPACE_PATH" ]; then

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -1,16 +1,31 @@
 #!/bin/bash
-if [[ "$EUID" -ne 0 ]]; then 
-  echo "Please run as root/sudo"
+
+if [ -f /usr/sbin/start-systemd-namespace ] && [ "$1" != "--force" ]; then
+  echo "It appears you have already installed the systemd hack."
+  echo "To forcibly reinstall, run this script with the \`--force\` parameter."
   exit
 fi
-apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
-cp ./start-systemd-namespace /usr/sbin/.
-cp ./enter-systemd-namespace /usr/sbin/.
-chmod +x /usr/sbin/enter-systemd-namespace
-echo 'Defaults        env_keep += WSLPATH' | EDITOR='tee -a' visudo
-echo 'Defaults        env_keep += WSLENV' | EDITOR='tee -a' visudo
-echo 'Defaults        env_keep += WSL_INTEROP' | EDITOR='tee -a' visudo
-echo 'Defaults        env_keep += WSL_DISTRO_NAME' | EDITOR='tee -a' visudo
-echo 'Defaults        env_keep += PRE_NAMESPACE_PATH' | EDITOR='tee -a' visudo
-echo '%sudo ALL=(ALL) NOPASSWD: /usr/sbin/enter-systemd-namespace' | EDITOR='tee -a' visudo
+
+self_dir="$(dirname $0)"
+
+sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
+
+sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace
+sudo cp "$self_dir/enter-systemd-namespace" /usr/sbin/enter-systemd-namespace
+sudo chmod +x /usr/sbin/enter-systemd-namespace
+
+sudo tee /etc/sudoers.d/systemd-namespace <<EOF
+Defaults        env_keep += WSLPATH
+Defaults        env_keep += WSLENV
+Defaults        env_keep += WSL_INTEROP
+Defaults        env_keep += WSL_DISTRO_NAME
+Defaults        env_keep += PRE_NAMESPACE_PATH
+%sudo ALL=(ALL) NOPASSWD: /usr/sbin/enter-systemd-namespace
+EOF
+
 sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/bash.bashrc
+
+if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ] && [ "$(head -n1  /proc/sys/fs/binfmt_misc/WSLInterop)" == "enabled" ]; then
+  cmd.exe /C setx WSLENV BASH_ENV/u
+  cmd.exe /C setx BASH_ENV /etc/bash.bashrc
+fi


### PR DESCRIPTION
Many many changes here. ZSH now works when set as default user shell. Ubuntu 20.04 now works with changed `daemonize` location: fixes #3

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>