### PR TITLE
Fix nested entering in the namespace

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -14,11 +14,11 @@ else
     exit 1
 fi
 
-SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
+SYSTEMD_PID="$(ps -efw | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
 if [ -z "$SYSTEMD_PID" ]; then
     "$DAEMONIZE" /usr/bin/unshare --fork --pid --mount-proc /lib/systemd/systemd --system-unit=basic.target
     while [ -z "$SYSTEMD_PID" ]; do
-        SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
+        SYSTEMD_PID="$(ps -efw | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
     done
 fi
 

--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SYSTEMD_PID="$(ps -ef | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
+SYSTEMD_PID="$(ps -efw | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
 if [ "$LOGNAME" != "root" ] && ( [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" != "1" ] ); then
     export | \
         grep -E -v "^(declare -x )?BASH(=.*)?\$" | \


### PR DESCRIPTION
This change ensures that if the terminal isn't wide enough
for the regular ps -ef command to spell out the full command
of the process the script doesn't break. Without the "-w"
switch ("ignore width"), the command line would become
truncated and "grep" would fail to find an existing systemd
process.

Signed-off-by: Paul-Stelian Olaru <olarupaulstelian97@gmail.com>