### PR TITLE
Updated README to comply with the latest state of the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ubuntu-wsl2-systemd-script
 Script to enable systemd support on current Ubuntu WSL2 images from the Windows store. 
-Tested on 18.04 and the versionless (current) version of Ubuntu from the Windows Store.
+Tested on 18.04, 20.04 and the versionless (current) version of Ubuntu from the Windows Store.
 I am not responsible for broken installations, fights with your roommates and police ringing your door ;-).
 
 Instructions from [the snapcraft forum](https://forum.snapcraft.io/t/running-snaps-on-wsl2-insiders-only-for-now/13033) turned into a script. Thanks to [Daniel](https://forum.snapcraft.io/u/daniel) on the Snapcraft forum! 
@@ -10,10 +10,8 @@ Instructions from [the snapcraft forum](https://forum.snapcraft.io/t/running-sna
 ```sh
 git clone https://github.com/DamionGans/ubuntu-wsl2-systemd-script.git
 cd ubuntu-wsl2-systemd-script/
-sudo bash ubuntu-wsl2-systemd-script.sh
+bash ubuntu-wsl2-systemd-script.sh
 # Enter your password and wait until the script has finished
-cmd.exe /C setx WSLENV BASH_ENV/u
-cmd.exe /C setx BASH_ENV /etc/bash.bashrc
 ```
 ### Then restart the Ubuntu shell and try running systemctl
 ```sh


### PR DESCRIPTION
I made some changes to the readme file:
- List Ubuntu version 20.04 as tested
- Remove sudo before bash as /mnt/c/Windows/System32 is not default in the $PATH for the root user but is for the normal user (needed for the cmd.exe commands)
- Remove the now redundant cmd.exe instructions as they get executed inside the script properly now