### PR TITLE
Avoid false positive to get home directory

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -22,7 +22,7 @@ if [ -z "$SYSTEMD_PID" ]; then
     done
 fi
 
-USER_HOME="$(getent passwd | awk '{ FS=":" } /'"^$SUDO_USER"'/ {print $6}')"
+USER_HOME="$(getent passwd | awk -F: '$1=="'"$SUDO_USER"'" {print $6}')"
 if [ -n "$SYSTEMD_PID" ] && [ "$SYSTEMD_PID" != "1" ]; then
     if [ -n "$1" ] && [ "$1" != "bash --login" ] && [ "$1" != "/bin/bash --login" ]; then
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \


### PR DESCRIPTION
First of all, thanks for creating and sharing a great script to run systemd!

I noticed https://github.com/DamionGans/ubuntu-wsl2-systemd-script/commit/bb2822c776512345aa597bab9e51d04a4c346239 is somewhat avoiding false positive but not perfect (ex: ^root matches rootfoo).

Another solution would be adding colon after $SUDO_USER and adding BEGIN
for settings FS  like below:
```
$ SUDO_USER=root; USER_HOME="$(getent passwd | awk 'BEGIN { FS=":" } /^'"$SUDO_USER"':/ {print $6}')"; echo $USER_HOME
/root
```

However I think this is clearer.
```
$ SUDO_USER=root; USER_HOME="$(getent passwd | awk -F: '$1=="'"$SUDO_USER"'" {print $6}')"; echo $USER_HOME
/root
```