### PR TITLE
Put spaces between multiple ENV=VAR for login command

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -31,7 +31,7 @@ if [ -n "$SYSTEMD_PID" ] && [ "$SYSTEMD_PID" != "1" ]; then
     else
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
             /bin/login -p -f "$SUDO_USER" \
-            $(/bin/cat "$USER_HOME/.systemd-env" | xargs printf '%q')
+            $(/bin/cat "$USER_HOME/.systemd-env" | xargs printf ' %q')
     fi
     echo "Existential crisis"
 fi


### PR DESCRIPTION
Without this fix (actually no newline at the end)
```
$ echo -n -e 'ENV1="VAR1"\nENV2="VAR2"\n' | xargs printf '%q'
'ENV1=VAR1''ENV2=VAR2'
```

With this fix (actually no newline at the end)
```
$ echo -n -e 'ENV1="VAR1"\nENV2="VAR2"\n' | xargs printf ' %q'
 'ENV1=VAR1' 'ENV2=VAR2'
```