### PR TITLE
one-line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ Instructions from [the snapcraft forum](https://forum.snapcraft.io/t/running-sna
 ## Usage
 ### Run the script and commands
 ```sh
-git clone https://github.com/DamionGans/ubuntu-wsl2-systemd-script.git
-cd ubuntu-wsl2-systemd-script/
-bash ubuntu-wsl2-systemd-script.sh
+curl "https://raw.githubusercontent.com/DamionGans/ubuntu-wsl2-systemd-script/master/ubuntu-wsl2-systemd-script.sh" | bash
 # Enter your password and wait until the script has finished
 ```
 ### Then restart the Ubuntu shell and try running systemctl

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -8,7 +8,10 @@ fi
 
 self_dir="$(dirname $0)"
 
-sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
+sudo apt-get update && sudo apt-get install -yqq git daemonize dbus-user-session fontconfig
+
+git clone https://github.com/DamionGans/ubuntu-wsl2-systemd-script.git
+cd ubuntu-wsl2-systemd-script
 
 sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace
 sudo cp "$self_dir/enter-systemd-namespace" /usr/sbin/enter-systemd-namespace


### PR DESCRIPTION
This pull request makes it possible to use systemd by typing just one line of code.

It downloads the install script using `curl` and pipes it into bash where it gets executed. The script then installs `git` along with all other dependencies, clones the repository and continues normally.

In order to test it, the command would be `curl "https://raw.githubusercontent.com/danthe1st/ubuntu-wsl2-systemd-script/master/ubuntu-wsl2-systemd-script.sh" | bash` until this pull request is merged as the script is only available in the fork.