### PR TITLE
Add binfmt_misc override

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -14,12 +14,13 @@ else
     exit 1
 fi
 
-SYSTEMD_PID="$(ps -efw | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
+SYSTEMD_EXE="/lib/systemd/systemd --system-unit=basic.target"
+SYSTEMD_PID="$(ps -efw | grep "$SYSTEMD_EXE"'$' | grep -v unshare | awk '{print $2}')"
 if [ -z "$SYSTEMD_PID" ]; then
-    "$DAEMONIZE" /usr/bin/unshare --fork --pid --mount-proc /lib/systemd/systemd --system-unit=basic.target
-    while [ -z "$SYSTEMD_PID" ]; do
-        SYSTEMD_PID="$(ps -efw | grep '/lib/systemd/systemd --system-unit=basic.target$' | grep -v unshare | awk '{print $2}')"
-    done
+    "$DAEMONIZE" /usr/bin/unshare --fork --pid --mount-proc bash -c 'export container=wsl; mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc; exec '"$SYSTEMD_EXE"
+    echo "Sleeping for 2 seconds to let systemd settle"
+    sleep 2
+    SYSTEMD_PID="$(ps -efw | grep "$SYSTEMD_EXE"'$' | grep -v unshare | awk '{print $2}')"
 fi
 
 USER_HOME="$(getent passwd | awk -F: '$1=="'"$SUDO_USER"'" {print $6}')"
@@ -27,11 +28,12 @@ if [ -n "$SYSTEMD_PID" ] && [ "$SYSTEMD_PID" != "1" ]; then
     if [ -n "$1" ] && [ "$1" != "bash --login" ] && [ "$1" != "/bin/bash --login" ]; then
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
             /usr/bin/sudo -H -u "$SUDO_USER" \
-            /bin/bash -c 'set -a; source "$HOME/.systemd-env"; set +a; exec bash -c '"$(printf "%q" "$@")"
+            /bin/bash -c 'set -a; [ -f "$HOME/.systemd-env" ] && source "$HOME/.systemd-env"; set +a; exec bash -c '"$(printf "%q" "$@")"
     else
         exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
             /bin/login -p -f "$SUDO_USER" \
-            $(/bin/cat "$USER_HOME/.systemd-env" | xargs printf ' %q')
+            $([ -f "$USER_HOME/.systemd-env" ] && /bin/cat "$USER_HOME/.systemd-env" | xargs printf ' %q')
     fi
     echo "Existential crisis"
+    exit 1
 fi

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -14,7 +14,7 @@ sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace
 sudo cp "$self_dir/enter-systemd-namespace" /usr/sbin/enter-systemd-namespace
 sudo chmod +x /usr/sbin/enter-systemd-namespace
 
-sudo tee /etc/sudoers.d/systemd-namespace <<EOF
+sudo tee /etc/sudoers.d/systemd-namespace >/dev/null <<EOF
 Defaults        env_keep += WSLPATH
 Defaults        env_keep += WSLENV
 Defaults        env_keep += WSL_INTEROP
@@ -24,9 +24,24 @@ Defaults        env_keep += PRE_NAMESPACE_PWD
 %sudo ALL=(ALL) NOPASSWD: /usr/sbin/enter-systemd-namespace
 EOF
 
-sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/bash.bashrc
+if ! grep 'start-systemd-namespace' /etc/bash.bashrc >/dev/null; then
+  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/bash.bashrc
+fi
+
+sudo rm /etc/systemd/user/sockets.target.wants/dirmngr.socket
+sudo rm /etc/systemd/user/sockets.target.wants/gpg-agent*.socket
+sudo rm /lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount
+sudo rm /lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+sudo rm /lib/systemd/system/sysinit.target.wants/systemd-binfmt.service
 
 if [ -f /proc/sys/fs/binfmt_misc/WSLInterop ] && [ "$(head -n1  /proc/sys/fs/binfmt_misc/WSLInterop)" == "enabled" ]; then
   cmd.exe /C setx WSLENV BASH_ENV/u
   cmd.exe /C setx BASH_ENV /etc/bash.bashrc
+else
+  echo
+  echo "You need to manually run the following two commands in Windows' cmd.exe:"
+  echo
+  echo "  setx WSLENV BASH_ENV/u"
+  echo "  setx BASH_ENV /etc/bash.bashrc"
+  echo
 fi


### PR DESCRIPTION
The changes are:

- Ensure we always use the same `systemd` command line if it is ever changed in one place it is updated in all other places via using a variable
- Don't go into an infinite loop waiting for systemd to start
- Don't try to use `$HOME/.systemd-env` if it doesn't exist
- Don't update `/etc/bash.bashrc` if the changes are already present - e.g. if the install script is run multiple times
- Disable systemd's attempts to re-mount `/proc/sys/fs/binfmt_misc` because it is already mounted by WSL and the re-mount breaks WSL Interoparability (Issue #15)
- Provide manual command instructions in the case that we can't automatically update the Windows environment using WSL Interoperability

Fixes #15

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>