### PR TITLE
Update system clock before update apt

### DIFF
--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -8,6 +8,7 @@ fi
 
 self_dir="$(dirname $0)"
 
+sudo hwclock -s
 sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
 
 sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace


### PR DESCRIPTION
After WSL2 sleeps, the clock inside VM (WSL2) may get mis-matched to Windows clock ( https://github.com/microsoft/WSL/issues/4245 ).

And this can cause failing `apt update`, the solution from Microsoft (https://github.com/microsoft/WSL/issues/4245#issuecomment-510238198) is using `sudo hwclock -s` to update the clock before `apt update`.