### PR TITLE
Install for more shells than Bash

### DIFF
--- a/fish/enter-systemd-namespace.fish
+++ b/fish/enter-systemd-namespace.fish
@@ -1,0 +1,51 @@
+#!/usr/bin/env fish
+
+if test "$LOGNAME" != "root";
+    echo "You need to run "(basename (status -f))" through sudo"
+    exit 1
+end
+
+if test -x /usr/sbin/daemonize;
+    set DAEMONIZE /usr/sbin/daemonize
+else if test -x /usr/bin/daemonize;
+    set DAEMONIZE /usr/bin/daemonize
+else
+    echo "Cannot execute daemonize to start systemd."
+    exit 1
+end
+
+if ! command -s /lib/systemd/systemd > /dev/null;
+    echo "Cannot execute /lib/systemd/systemd."
+    exit 1
+end
+
+if ! command -s /usr/bin/unshare > /dev/null;
+    echo "Cannot execute /usr/bin/unshare."
+    exit 1
+end
+
+set SYSTEMD_EXE "/lib/systemd/systemd --unit=basic.target"
+set SYSTEMD_PID (ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')
+if test -z "$SYSTEMD_PID";
+    $DAEMONIZE /usr/bin/unshare --fork --pid --mount-proc fish -c 'export container=wsl; mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc; exec '"$SYSTEMD_EXE"
+    while test -z "$SYSTEMD_PID"
+        echo "Sleeping for 1 second to let systemd settle"
+        sleep 1
+        set SYSTEMD_PID (ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')
+    end
+end
+
+set USER_HOME (getent passwd | awk -F: '$1=="'"$SUDO_USER"'" {print $6}')
+if test -n "$SYSTEMD_PID" && test "$SYSTEMD_PID" != "1";
+    if test -n "$argv[1]" && "$argv[1]" != "fish --login" && "$argv[1]" != "/usr/bin/fish --login";
+        exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
+            /usr/bin/sudo -H -u "$SUDO_USER" \
+            /usr/bin/fish -c 'set -a; [ -f "$HOME/.systemd-env" ] && source "$HOME/.systemd-env"; set +a; exec fish -c '"(printf "%q" "$argv")"
+    else
+        exec /usr/bin/nsenter -t "$SYSTEMD_PID" -a \
+            /bin/login -p -f "$SUDO_USER" \
+            (test -f "$USER_HOME/.systemd-env" &&  /bin/cat "$USER_HOME/.systemd-env" | xargs printf ' %q' )
+    end
+    echo "Existential crisis"
+    exit 1
+end

--- a/fish/start-systemd-namespace.fish
+++ b/fish/start-systemd-namespace.fish
@@ -1,0 +1,23 @@
+#!/usr/bin/env fish
+if status --is-interactive
+set SYSTEMD_EXE "/lib/systemd/systemd --unit=basic.target"
+set SYSTEMD_PID (ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')
+if test \( "$LOGNAME" != "root" \) && test -z "$SYSTEMD_PID" -o "$SYSTEMD_PID" != "1";
+    set -xL | sed -e '/^IFS=".*[^"]$/{N;s/\n//}' | \
+        grep -E -v "^(BASH|BASH_ENV|DIRSTACK|EUID|GROUPS|HOME|HOSTNAME|\
+IFS|LANG|LOGNAME|MACHTYPE|MAIL|NAME|OLDPWD|OPTERR|\
+OSTYPE|PATH|PIPESTATUS|POSIXLY_CORRECT|PPID|PS1|PS4|\
+SHELL|SHELLOPTS|SHLVL|SYSTEMD_PID|UID|USER|_)(=|\$)" > "$HOME/.systemd-env"
+    set -x PRE_NAMESPACE_PATH $PATH
+    set -x PRE_NAMESPACE_PWD (pwd)
+    exec sudo /etc/fish/conf.d/enter-systemd-namespace $BASH_EXECUTION_STRING
+end
+if test -n "$PRE_NAMESPACE_PATH";
+    set -x PATH $PRE_NAMESPACE_PATH
+    set -u PRE_NAMESPACE_PATH
+end
+if test -n "$PRE_NAMESPACE_PWD";
+    cd $PRE_NAMESPACE_PWD
+    set -u PRE_NAMESPACE_PWD
+end
+end

--- a/fish/ubuntu-wsl2-systemd-script.fish
+++ b/fish/ubuntu-wsl2-systemd-script.fish
@@ -1,0 +1,68 @@
+#!/usr/bin/env fish
+
+if test \( -f /usr/sbin/start-systemd-namespace \)  -a \( "$argv[1]" != "--force" \) ;
+  echo "It appears you have already installed the systemd hack."
+  echo "To forcibly reinstall, run this script with the \`--force\` parameter."
+  exit
+end
+
+set self_dir (pwd)
+
+function interop_prefix
+
+	set win_location "/mnt/"
+	if test -f /etc/wsl.conf;
+		set tmp (awk -F '=' '/root/ {print $2}' /etc/wsl.conf | awk '{$1=$1;print}')
+		test \( "$tmp" == "" \) -o \( win_location="$tmp" \)
+		set -u tmp
+	end
+	echo "$win_location"
+
+	set -u win_location
+end
+
+function sysdrive_prefix 
+	set win_location (interop_prefix)
+	set hard_reset 0
+	for pt in (ls "$win_location"); do
+		if test (echo "$pt" | wc -l) -eq 1;
+			if test -d "$win_location$pt/Windows/System32";
+				set hard_reset 1
+				set win_location "$pt"
+				break
+			end
+		end 
+	end
+
+	if test $hard_reset -eq 0;
+		set win_location "c"
+	end
+
+	echo "$win_location"
+
+	set -u win_location
+	set -u hard_reset
+end
+
+sudo hwclock -s
+sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
+
+sudo cp "$self_dir/start-systemd-namespace.fish" /etc/fish/conf.d/start-systemd-namespace.fish
+sudo cp "$self_dir/enter-systemd-namespace.fish" /etc/fish/conf.d/enter-systemd-namespace
+sudo chmod +x /etc/fish/conf.d/enter-systemd-namespace
+
+echo "
+Defaults        env_keep += WSLPATH
+Defaults        env_keep += WSLENV
+Defaults        env_keep += WSL_INTEROP
+Defaults        env_keep += WSL_DISTRO_NAME
+Defaults        env_keep += PRE_NAMESPACE_PATH
+Defaults        env_keep += PRE_NAMESPACE_PWD
+%sudo ALL=(ALL) NOPASSWD: /etc/fish/conf.d/enter-systemd-namespace
+" | sudo tee /etc/sudoers.d/systemd-namespace >/dev/null 
+
+sudo rm -f /etc/systemd/user/sockets.target.wants/dirmngr.socket
+sudo rm -f /etc/systemd/user/sockets.target.wants/gpg-agent*.socket
+sudo rm -f /lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.automount
+sudo rm -f /lib/systemd/system/sysinit.target.wants/proc-sys-fs-binfmt_misc.mount
+sudo rm -f /lib/systemd/system/sysinit.target.wants/systemd-binfmt.service

--- a/start-systemd-namespace.fish
+++ b/start-systemd-namespace.fish
@@ -10,7 +10,7 @@ OSTYPE|PATH|PIPESTATUS|POSIXLY_CORRECT|PPID|PS1|PS4|\
 SHELL|SHELLOPTS|SHLVL|SYSTEMD_PID|UID|USER|_)(=|\$)" > "$HOME/.systemd-env"
     set -x PRE_NAMESPACE_PATH $PATH
     set -x PRE_NAMESPACE_PWD (pwd)
-    exec sudo /etc/fish/conf.d/enter-systemd-namespace $BASH_EXECUTION_STRING
+    exec sudo /usr/sbin/enter-systemd-namespace $BASH_EXECUTION_STRING
 end
 if test -n "$PRE_NAMESPACE_PATH";
     set -x PATH $PRE_NAMESPACE_PATH

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -47,7 +47,12 @@ function sysdrive_prefix {
 sudo hwclock -s
 sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
 
+
+if cat /etc/shells | grep fish >/dev/null; then
+sudo cp "$self_dir/start-systemd-namespace.fish" /etc/fish/conf.d/start-systemd-namespace.fish
+fi
 sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace
+
 sudo cp "$self_dir/enter-systemd-namespace" /usr/sbin/enter-systemd-namespace
 sudo chmod +x /usr/sbin/enter-systemd-namespace
 
@@ -64,6 +69,10 @@ EOF
 if ! grep 'start-systemd-namespace' /etc/bash.bashrc >/dev/null; then
   sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/bash.bashrc
 fi
+if grep 'zsh' /etc/shells >/dev/null && ! grep 'start-systemd-namespace' /etc/zsh/zshrc >/dev/null; then
+  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/zsh/zshrc
+fi
+
 
 sudo rm -f /etc/systemd/user/sockets.target.wants/dirmngr.socket
 sudo rm -f /etc/systemd/user/sockets.target.wants/gpg-agent*.socket


### PR DESCRIPTION
Starts systemd through /etc/fish/conf.d/ if fish is opened in an interactive terminal.
enter-systemd-namespace isn't copied over as a .fish file, as that would have meant it would execute seperately from the start-systemd-namespace.fish

Visual Studio Code terminals have access to snap, and remote development for WSL works.
Tabs in Windows Terminal also work.