### PR TITLE
Fixed the script by chaging installation location

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ sudo apt install git
 to do so.
 ### Run the script and commands
 ```sh
+cd /
 git clone https://github.com/DamionGans/ubuntu-wsl2-systemd-script.git
 cd ubuntu-wsl2-systemd-script/
 bash ubuntu-wsl2-systemd-script.sh

--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -10,7 +10,7 @@ OSTYPE|PATH|PIPESTATUS|POSIXLY_CORRECT|PPID|PS1|PS4|\
 SHELL|SHELLOPTS|SHLVL|SYSTEMD_PID|UID|USER|_)(=|\$)" > "$HOME/.systemd-env"
     export PRE_NAMESPACE_PATH="$PATH"
     export PRE_NAMESPACE_PWD="$(pwd)"
-    exec sudo /usr/sbin/enter-systemd-namespace "$BASH_EXECUTION_STRING"
+    exec sudo /enter-systemd-namespace "$BASH_EXECUTION_STRING"
 fi
 if [ -n "$PRE_NAMESPACE_PATH" ]; then
     export PATH="$PRE_NAMESPACE_PATH"

--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -10,7 +10,7 @@ OSTYPE|PATH|PIPESTATUS|POSIXLY_CORRECT|PPID|PS1|PS4|\
 SHELL|SHELLOPTS|SHLVL|SYSTEMD_PID|UID|USER|_)(=|\$)" > "$HOME/.systemd-env"
     export PRE_NAMESPACE_PATH="$PATH"
     export PRE_NAMESPACE_PWD="$(pwd)"
-    exec sudo /enter-systemd-namespace "$BASH_EXECUTION_STRING"
+    exec sudo /ubuntu-wsl2-systemd-script/enter-systemd-namespace "$BASH_EXECUTION_STRING"
 fi
 if [ -n "$PRE_NAMESPACE_PATH" ]; then
     export PATH="$PRE_NAMESPACE_PATH"

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" != "--force" ]; then
-    if [ -f /usr/sbin/start-systemd-namespace ]; then
+    if [ -f /start-systemd-namespace ]; then
         echo "It appears you have already installed the systemd hack."
         echo "To forcibly reinstall, run this script with the \`--force\` parameter."
         exit
@@ -53,9 +53,9 @@ function sysdrive_prefix {
 sudo hwclock -s
 sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
 
-sudo cp "$self_dir/start-systemd-namespace" /usr/sbin/start-systemd-namespace
-sudo cp "$self_dir/enter-systemd-namespace" /usr/sbin/enter-systemd-namespace
-sudo chmod +x /usr/sbin/enter-systemd-namespace
+sudo cp "$self_dir/start-systemd-namespace" /start-systemd-namespace
+sudo cp "$self_dir/enter-systemd-namespace" /enter-systemd-namespace
+sudo chmod +x /enter-systemd-namespace
 
 sudo tee /etc/sudoers.d/systemd-namespace >/dev/null <<EOF
 Defaults        env_keep += WSLPATH
@@ -64,11 +64,11 @@ Defaults        env_keep += WSL_INTEROP
 Defaults        env_keep += WSL_DISTRO_NAME
 Defaults        env_keep += PRE_NAMESPACE_PATH
 Defaults        env_keep += PRE_NAMESPACE_PWD
-%sudo ALL=(ALL) NOPASSWD: /usr/sbin/enter-systemd-namespace
+%sudo ALL=(ALL) NOPASSWD: /enter-systemd-namespace
 EOF
 
 if ! grep 'start-systemd-namespace' /etc/bash.bashrc >/dev/null; then
-  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /usr/sbin/start-systemd-namespace\n" /etc/bash.bashrc
+  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /start-systemd-namespace\n" /etc/bash.bashrc
 fi
 
 sudo rm -f /etc/systemd/user/sockets.target.wants/dirmngr.socket

--- a/ubuntu-wsl2-systemd-script.sh
+++ b/ubuntu-wsl2-systemd-script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" != "--force" ]; then
-    if [ -f /start-systemd-namespace ]; then
+    if [ -f /ubuntu-wsl2-systemd-script/start-systemd-namespace ]; then
         echo "It appears you have already installed the systemd hack."
         echo "To forcibly reinstall, run this script with the \`--force\` parameter."
         exit
@@ -53,9 +53,7 @@ function sysdrive_prefix {
 sudo hwclock -s
 sudo apt-get update && sudo apt-get install -yqq daemonize dbus-user-session fontconfig
 
-sudo cp "$self_dir/start-systemd-namespace" /start-systemd-namespace
-sudo cp "$self_dir/enter-systemd-namespace" /enter-systemd-namespace
-sudo chmod +x /enter-systemd-namespace
+sudo chmod +x /ubuntu-wsl2-systemd-script/enter-systemd-namespace
 
 sudo tee /etc/sudoers.d/systemd-namespace >/dev/null <<EOF
 Defaults        env_keep += WSLPATH
@@ -64,11 +62,11 @@ Defaults        env_keep += WSL_INTEROP
 Defaults        env_keep += WSL_DISTRO_NAME
 Defaults        env_keep += PRE_NAMESPACE_PATH
 Defaults        env_keep += PRE_NAMESPACE_PWD
-%sudo ALL=(ALL) NOPASSWD: /enter-systemd-namespace
+%sudo ALL=(ALL) NOPASSWD: /ubuntu-wsl2-systemd-script/enter-systemd-namespace
 EOF
 
 if ! grep 'start-systemd-namespace' /etc/bash.bashrc >/dev/null; then
-  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /start-systemd-namespace\n" /etc/bash.bashrc
+  sudo sed -i 2a"# Start or enter a PID namespace in WSL2\nsource /ubuntu-wsl2-systemd-script/start-systemd-namespace\n" /etc/bash.bashrc
 fi
 
 sudo rm -f /etc/systemd/user/sockets.target.wants/dirmngr.socket


### PR DESCRIPTION
Hi,

I'm not suggesting that you merge this change. I am creating this pull request to let you know that **I managed to get the script working again** by changing the install location of the _enter-systemd-namespace_ and _start-systemd-namespace_ files. 

I put them both in _/ubuntu-wsl2-systemd-script_ which has an added benefit of making "updates" easier (if you git clone in /, you can update it by doing a git pull)

I'd improve the solution if I had time, but I imagine you probably will find a better fix :) 

Or you can just merge this and improve it after?

Good luck,

Namyts