### PR TITLE
BugFix: Remove unnecessary "export"

### DIFF
--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -3,13 +3,13 @@
 SYSTEMD_EXE="/lib/systemd/systemd --unit=basic.target"
 SYSTEMD_PID="$(ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')"
 if [ "$LOGNAME" != "root" ] && ( [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" != "1" ] ); then
+    PRE_NAMESPACE_PATH="$PATH"
+    PRE_NAMESPACE_PWD="$(pwd)"
     export | sed -e 's/^declare -x //;/^IFS=".*[^"]$/{N;s/\n//}' | \
         grep -E -v "^(BASH|BASH_ENV|DIRSTACK|EUID|GROUPS|HOME|HOSTNAME|\
 IFS|LANG|LOGNAME|MACHTYPE|MAIL|NAME|OLDPWD|OPTERR|\
 OSTYPE|PATH|PIPESTATUS|POSIXLY_CORRECT|PPID|PS1|PS4|\
 SHELL|SHELLOPTS|SHLVL|SYSTEMD_PID|UID|USER|_)(=|\$)" > "$HOME/.systemd-env"
-    export PRE_NAMESPACE_PATH="$PATH"
-    export PRE_NAMESPACE_PWD="$(pwd)"
     exec sudo /usr/sbin/enter-systemd-namespace "$BASH_EXECUTION_STRING"
 fi
 if [ -n "$PRE_NAMESPACE_PATH" ]; then


### PR DESCRIPTION
exports PRE_NAMESPACE_PWD and PRE_NAMESPACE_PATH variables to environment variables cause the PWD/PATH will set to  PRE_NAMESPACE_PWD/PRE_NAMESPACE_PATH every time while you start a bash.
(the unset does not work cause it can only unset local variables)

solution: removes "export" words at the start of the definition of  PRE_NAMESPACE_PWD and PRE_NAMESPACE_PATH